### PR TITLE
Point to unittest config for running smoke tests

### DIFF
--- a/dojo/unittests/test_endpoint_metadata.py
+++ b/dojo/unittests/test_endpoint_metadata.py
@@ -1,7 +1,4 @@
-import sys
-sys.path.append('..')
 from dojo.models import Product
-from dojo.models import System_Settings
 from dojo.models import Endpoint
 from dojo.endpoint import views
 from django.test import TestCase

--- a/entrypoint_scripts/test/travis-smoke-test.sh
+++ b/entrypoint_scripts/test/travis-smoke-test.sh
@@ -16,9 +16,9 @@ export CONTAINER_NAME=dojo
 docker build -t $REPO .
 
 # Launch one container per service
-container_id_worker=$(docker run -d --entrypoint=celery $REPO worker -A dojo -l info -c 1 -P solo)
-container_id_beat=$(docker run -d --entrypoint=celery $REPO beat -A dojo -l info)
-container_id_server=$(docker run -d --entrypoint=python $REPO manage.py runserver 0.0.0.0:8000)
+container_id_worker=$(docker run --env DJANGO_SETTINGS_MODULE=dojo.settings.unittest -d --entrypoint=celery $REPO worker -A dojo -l info -c 1 -P solo)
+container_id_beat=$(docker run --env DJANGO_SETTINGS_MODULE=dojo.settings.unittest -d --entrypoint=celery $REPO beat -A dojo -l info)
+container_id_server=$(docker run --env DJANGO_SETTINGS_MODULE=dojo.settings.unittest -d --entrypoint=python $REPO manage.py runserver 0.0.0.0:8000)
 
 # Wait for the container to spin up and gie it some time to fail
 sleep 10


### PR DESCRIPTION
This change forces the settings module configuration to be set to unittest in order not to rely on a running DB when smoke testing Celery processes. 

When submitting a pull request, please make sure you have completed the following checklist:

- [ ] Your code is pep8 compliant (Dojo's code isn't currently pep8 compliant, but we're trying to correct that)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation under the /docs folder
